### PR TITLE
chore: заведена базовая конфигурация репозитория

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,10 +1,20 @@
+# Не искать .editorconfig в родительских каталогах
 root = true
 
+# Значения по умолчанию для всех файлов
 [*]
+charset = utf-8
 end_of_line = lf
 insert_final_newline = true
-
-[*.{yml,yaml}]
+trim_trailing_whitespace = true
 indent_style = space
 indent_size = 2
-trim_trailing_whitespace = true
+
+# В Markdown два пробела в конце строки означают перенос,
+# поэтому подрезать хвостовые пробелы здесь нельзя.
+[*.md]
+trim_trailing_whitespace = false
+
+# Windows-скрипты
+[*.{bat,cmd,ps1}]
+end_of_line = crlf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,19 @@
+# По умолчанию: и в репозитории, и в рабочем каталоге — LF.
+# Скрипты действий исполняет Linux-раннер: файл, уехавший туда с CRLF,
+# падает на запуске сообщением `\r: not found`.
+* text=auto eol=lf
+
+# Скрипты с фиксированными окончаниями строк
+*.sh  text eol=lf
+*.cmd text eol=crlf
+*.bat text eol=crlf
+*.ps1 text eol=crlf
+
+# Бинарные ассеты (без EOL-нормализации и diff'а)
+*.png  binary
+*.jpg  binary
+*.jpeg binary
+*.gif  binary
+*.webp binary
+*.ico  binary
+*.pdf  binary

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# Каталоги и файлы редакторов
+.vscode/*
+!.vscode/extensions.json
+!.vscode/settings.json
+.idea/
+*.swp
+
+# Мусор ОС
+.DS_Store
+Thumbs.db
+
+# Логи
+*.log

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,9 @@
+{
+  "recommendations": [
+    "editorconfig.editorconfig",
+    "esbenp.prettier-vscode",
+    "redhat.vscode-yaml",
+    "github.vscode-github-actions",
+    "timonwong.shellcheck"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,15 @@
+{
+  "files.eol": "\n",
+
+  // Prettier назначен форматтером, но formatOnSave не включается: в репозитории
+  // три десятка файлов YAML, и при первой же правке воркфлоу prettier переписал
+  // бы его целиком. Форматирование остаётся ручным действием.
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "prettier.enable": true,
+  "prettier.requireConfig": true,
+
+  "[yaml]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
+  "[json]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
+  "[jsonc]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
+  "[markdown]": { "editor.defaultFormatter": "esbenp.prettier-vscode" }
+}


### PR DESCRIPTION
Заводит общий для репозиториев организации набор конфигурационных файлов, не
зависящий от языка проекта. Языко-специфичного слоя (`package.json`,
`pyproject.toml`, `Directory.Build.props`) здесь нет — в репозитории только YAML
и bash.

## Что вошло

- **`.gitattributes`** (новый). Главная причина правки: в репозитории три
  bash-скрипта, которые исполняет Linux-раннер, а защиты от CRLF не было. Сейчас
  все файлы в LF, но первая же правка `.sh` из Windows-редактора уехала бы в
  CRLF и сломала запуск сообщением `\r: not found`.
- **`.editorconfig`**. Добавлены `charset`, значения отступов по умолчанию,
  исключение для Markdown и правило для Windows-скриптов.
- **`.gitignore`** (новый). Мусор ОС и редакторов; сборки в репозитории нет,
  поэтому список короткий.
- **`.vscode/extensions.json`, `.vscode/settings.json`** (новые). К общим для
  организации EditorConfig и Prettier добавлены YAML, GitHub Actions и
  ShellCheck — по содержимому репозитория.

## Решения, которые из диффа не выводятся

- В `.editorconfig` нет `max_line_length`, хотя у соседей он есть (80 в
  JS-репозитории, 100 в dotnet). Здесь 171 строка YAML длиннее 80 и 88 строк
  длиннее 100 — линейка показывала бы нарушение почти во всех воркфлоу.
- В `settings.json` не включён `formatOnSave`: prettier переписал бы воркфлоу
  целиком при первой же правке. Форматирование остаётся ручным действием.
- Отдельных блоков `[*.{yml,yaml}]`, `[*.json]`, `[*.sh]` в `.editorconfig` нет —
  отступ в 2 пробела задан по умолчанию и покрывает и YAML, и bash.

## Что намеренно не вошло

`.github/dependabot.yml`, `CONTRIBUTING.md`, самопроверка в CI и подъём
отставших пинов экшенов (`@v4`/`@v5` против `@v7` у соседних репозиториев) —
отдельными задачами. Текущее состояние планируется зафиксировать в релизной
ветке, поэтому поведение воркфлоу этот PR не трогает.

## Проверка

- `git add --renormalize .` не меняет ни одного существующего файла;
- `git check-attr text eol` для `.sh` даёт `text: set`, `eol: lf`;
- `git ls-files --eol` — все файлы в индексе в LF;
- `.vscode/extensions.json` и `settings.json` не игнорируются,
  `.vscode/launch.json` — игнорируется.

Closes #4
