### PR TITLE
fix: восстановлен старт docker-cleanup по расписанию

### DIFF
--- a/.github/workflows/docker-cleanup.yml
+++ b/.github/workflows/docker-cleanup.yml
@@ -11,19 +11,23 @@ on:
       days-old:
         required: false
         type: string
-        default: "1"
+        default: "0"
         description: Удалить образы старше чем D дней
 
       hours-old:
         required: false
         type: string
-        default: "0"
+        default: "1"
         description: Удалить образы старше чем D дней и H часов (0–23)
 
+      # Строка, а не boolean: вызывающий workflow пробрасывает сюда
+      # ${{ inputs.show-only }}, а при триггере schedule контекст inputs пуст
+      # и выражение даёт ''. В boolean-вход пустая строка не приводится —
+      # workflow не стартует вовсе.
       show-only:
         required: false
-        default: false
-        type: boolean
+        type: string
+        default: "false"
         description: Только показать список (не удалять)
 
 jobs:
@@ -38,6 +42,8 @@ jobs:
       - name: 🧹 Cleanup Docker images
         uses: nii-energomash/automation/.github/actions/docker-cleanup@master
         with:
+          # Умолчания входов тут не спасают: вызывающий workflow передаёт
+          # значение явно, и пустая строка со schedule перекрывает default.
           days-old: ${{ inputs.days-old || '0' }}
           hours-old: ${{ inputs.hours-old || '1' }}
-          show-only: ${{ inputs.show-only || false }}
+          show-only: ${{ inputs.show-only || 'false' }}

--- a/examples/github/docker/docker-cleanup.yml
+++ b/examples/github/docker/docker-cleanup.yml
@@ -37,6 +37,9 @@ jobs:
   cleanup:
     uses: nii-energomash/automation/.github/workflows/docker-cleanup.yml@master
     with:
-      days-old: ${{ inputs.days-old }}
-      hours-old: ${{ inputs.hours-old }}
-      show-only: ${{ inputs.show-only }}
+      # При триггере schedule контекст inputs пуст и каждое выражение даёт ''.
+      # Переиспользуемый workflow ждёт строки, поэтому show-only приводится
+      # к 'true'/'false' явно, а не пробрасывается булевым значением.
+      days-old: ${{ inputs.days-old || '0' }}
+      hours-old: ${{ inputs.hours-old || '1' }}
+      show-only: ${{ inputs.show-only && 'true' || 'false' }}


### PR DESCRIPTION
Переиспользуемый `docker-cleanup` не отрабатывал ни разу: в `kdepa-spa` 197
запусков и 197 падений, все по `schedule`, все — на старте, с пустым списком
jobs. Причина в том, что при `schedule` контекст `inputs` пуст, проброс
`show-only: ${{ inputs.show-only }}` даёт `''`, а вход объявлен `type: boolean`.
Пустая строка в булево не приводится, и workflow не стартует.

## Что вошло

- **`show-only` в переиспользуемом workflow переведён в `type: string`**
  с умолчанием `"false"`. Правка на этой стороне, а не только в примере,
  потому что тип проверяется на границе «вызывающий → переиспользуемый»:
  так чинится и `kdepa-spa`, и любой будущий потребитель без изменений у них.
- **Объявленные умолчания `days-old` и `hours-old` приведены к `"0"` и `"1"`.**
  Были `"1"` и `"0"`, при том что проброс в действие идёт как
  `${{ inputs.days-old || '0' }}` / `${{ inputs.hours-old || '1' }}` —
  объявленные значения не срабатывали никогда, фактическое поведение всегда
  было «старше часа».
- **В примере входы приводятся к строке явно:**
  `show-only: ${{ inputs.show-only && 'true' || 'false' }}`, у `days-old`
  и `hours-old` появились фолбэки. Вход самого примера остаётся `type: boolean`
  ради галочки в UI при ручном запуске.

## Решения, которые из диффа не выводятся

- Форма `&& 'true' || 'false'` вместо `|| false`: переиспользуемый workflow
  теперь ждёт строку, и полагаться на неявное приведение булева значения
  к строке не хочется.
- Фолбэки `|| '0'` и `|| '1'` в пробросе оставлены, хотя умолчания входов
  теперь совпадают с ними. Умолчание не применяется, когда вызывающий передаёт
  значение явно, а при `schedule` он передаёт пустую строку.

## Что намеренно не вошло

Дефект в самом `cleanup.sh` — обращение к `/users/{owner}/packages/...`
вместо `/orgs/{org}/packages/...` для пакета, принадлежащего организации.
До скрипта дело ни разу не доходило, дефект был замаскирован этим падением.
Отдельной задачей.

## Проверка

- Оба файла разбираются YAML-парсером; `git ls-files --eol` — LF.
- На потребителе: запустить `docker-cleanup` вручную (`workflow_dispatch`)
  и дождаться очередного `schedule`. Оба запуска должны стартовать и дойти
  до шага чистки — сейчас `schedule` даёт startup failure стабильно.

Closes #8
