### PR TITLE
fix: docker-cleanup обращается к пакетам организации

### DIFF
--- a/.github/actions/docker-cleanup/action.yml
+++ b/.github/actions/docker-cleanup/action.yml
@@ -1,10 +1,14 @@
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 
-name: Docrer cleanup
+name: Docker cleanup
 description: >
   Удаление docker-образов.
   Будут удалены образы, теги которых начинаются с 'sha-', и которые старше указанного возраста.
-  Требуется permissions.packages.write и permissions.contents.read
+  Требуется permissions.packages.write и permissions.contents.read.
+  Путь до пакета выбирается по типу владельца репозитория: у организации это
+  /orgs/{org}/packages/..., у пользователя — /users/{username}/packages/...
+  github.token удаляет версии только у пакета, привязанного к репозиторию;
+  для пакета без такой привязки нужен PAT с правом delete:packages
 
 inputs:
   days-old:

--- a/.github/actions/docker-cleanup/cleanup.sh
+++ b/.github/actions/docker-cleanup/cleanup.sh
@@ -15,6 +15,7 @@ set -euo pipefail
 DAYS_OLD="${DAYS_OLD:-0}"
 HOURS_OLD="${HOURS_OLD:-1}"
 SHOW_ONLY="${SHOW_ONLY:-false}"
+TAG_PREFIX="sha-"
 
 #######################################
 # Derived values
@@ -43,14 +44,38 @@ if [[ "$SHOW_ONLY" != "true" && "$SHOW_ONLY" != "false" ]]; then
 fi
 
 #######################################
+# Package endpoint
+#######################################
+
+# Путь до пакета зависит от того, кому он принадлежит: у организации это
+# /orgs/{org}/packages/..., у пользователя — /users/{username}/packages/...
+# Перепутанный путь даёт 404, поэтому тип владельца выясняется в рантайме,
+# а не зашивается в скрипт.
+OWNER_TYPE="$(gh api "users/${OWNER}" --jq '.type' 2>/dev/null || true)"
+
+case "$OWNER_TYPE" in
+  Organization) OWNER_PATH="orgs/${OWNER}" ;;
+  User) OWNER_PATH="users/${OWNER}" ;;
+  *)
+    echo "❌ Не удалось определить тип владельца '${OWNER}'"
+    echo "   Получено: '${OWNER_TYPE:-<пусто>}', ожидалось 'Organization' или 'User'"
+    exit 1
+    ;;
+esac
+
+PACKAGE_PATH="${OWNER_PATH}/packages/container/${REPO}"
+
+#######################################
 # Time calculation
 #######################################
 
 CUTOFF_TS="$(date -d "${DAYS_OLD} days ${HOURS_OLD} hours ago" +%s)"
 
 echo "🧹 Docker cleanup"
-echo "Owner:        $OWNER"
+echo "Owner:        $OWNER ($OWNER_TYPE)"
 echo "Repository:   $REPO"
+echo "Package path: $PACKAGE_PATH"
+echo "Tag prefix:   $TAG_PREFIX"
 echo "Days old:     $DAYS_OLD"
 echo "Hours old:    $HOURS_OLD"
 echo "Show only:    $SHOW_ONLY"
@@ -58,25 +83,43 @@ echo "Cutoff time:  $(date -d "@$CUTOFF_TS")"
 echo
 
 #######################################
-# Fetch & process package versions
+# Fetch package versions
 #######################################
 
 echo "📦 Fetching container versions…"
 
-gh api \
-  "/users/${OWNER}/packages/container/${REPO}/versions" \
-  --paginate \
-  -q "
-    .[] |
-    select(.metadata.container.tags[]? | startswith(\"sha-\")) |
-    select((.updated_at | fromdateiso8601) < ${CUTOFF_TS}) |
-    {
+# any(...) вместо tags[]?: с генератором внутри select версия попадала
+# в выборку столько раз, сколько у неё подходящих тегов, и один и тот же
+# id удалялся дважды.
+JQ_FILTER="
+  .[]
+  | select(any(.metadata.container.tags[]?; startswith(\"${TAG_PREFIX}\")))
+  | select((.updated_at | fromdateiso8601) < ${CUTOFF_TS})
+  | {
       id: .id,
       updated_at: .updated_at,
       tags: .metadata.container.tags
     }
-  " |
-while read -r version; do
+"
+
+if ! CANDIDATES="$(gh api "${PACKAGE_PATH}/versions" --paginate --jq "$JQ_FILTER")"; then
+  echo "❌ Не удалось получить список версий пакета по пути ${PACKAGE_PATH}"
+  exit 1
+fi
+
+#######################################
+# Process candidates
+#######################################
+
+FOUND=0
+DELETED=0
+SKIPPED=0
+
+while IFS= read -r version; do
+  [ -z "$version" ] && continue
+
+  FOUND=$((FOUND + 1))
+
   ID="$(jq -r '.id' <<<"$version")"
   TAGS="$(jq -r '.tags | join(", ")' <<<"$version")"
   UPDATED="$(jq -r '.updated_at' <<<"$version")"
@@ -88,12 +131,37 @@ while read -r version; do
 
   if [[ "$SHOW_ONLY" == "true" ]]; then
     echo "    (dry-run, not deleting)"
+    echo
+    continue
+  fi
+
+  echo "    Deleting version $ID"
+
+  # Версию мог удалить параллельный прогон, поэтому 404 — не ошибка.
+  if DELETE_OUTPUT="$(gh api --method DELETE "${PACKAGE_PATH}/versions/${ID}" --silent </dev/null 2>&1)"; then
+    DELETED=$((DELETED + 1))
+  elif grep -q "HTTP 404" <<<"$DELETE_OUTPUT"; then
+    echo "    ⏭️  Версия уже отсутствует (404)"
+    SKIPPED=$((SKIPPED + 1))
   else
-    echo "    Deleting version $ID"
-    gh api \
-      --method DELETE \
-      "/users/${OWNER}/packages/container/${REPO}/versions/${ID}"
+    echo "    ❌ Не удалось удалить версию $ID"
+    echo "$DELETE_OUTPUT"
+    exit 1
   fi
 
   echo
-done
+done <<<"$CANDIDATES"
+
+#######################################
+# Summary
+#######################################
+
+echo "✅ Готово"
+echo "   Кандидатов найдено: $FOUND"
+
+if [[ "$SHOW_ONLY" == "true" ]]; then
+  echo "   Удалено:            0 (dry-run)"
+else
+  echo "   Удалено:            $DELETED"
+  echo "   Пропущено (404):    $SKIPPED"
+fi


### PR DESCRIPTION
После #8 workflow стартует, но сам скрипт чистки работать не мог: он обращался
к `/users/{owner}/packages/container/{repo}/versions` — пути для пакета,
принадлежащего пользователю. Пакеты лежат под организацией, для неё путь другой:
`/orgs/{org}/packages/...`. Дефект не проявлялся в логах только потому, что до
скрипта дело ни разу не доходило.

## Что вошло

- **Путь до пакета выбирается по типу владельца.** `gh api users/$OWNER --jq .type`
  даёт `Organization` или `User`, отсюда `orgs/…` либо `users/…`. Действие
  остаётся пригодным и для личных репозиториев. Неопознанный тип валит шаг
  с сообщением, а не уходит молча в 404.
- **Кандидаты дедуплицируются.** Было
  `select(.metadata.container.tags[]? | startswith("sha-"))` — генератор внутри
  `select` отдавал версию по разу на каждый подходящий тег, и один и тот же id
  удалялся дважды. Стало `select(any(.metadata.container.tags[]?; startswith("sha-")))`:
  двухаргументный `any` возвращает одно булево значение.
- **Отказ API больше не выглядит как пустой список.** Список версий берётся
  в переменную с явной проверкой кода возврата; раньше `gh api | while read`
  давал при ошибке ровно то же, что и при отсутствии кандидатов.
- **Цикл вынесен из конвейера** в текущую оболочку — появились счётчики
  и итоговая сводка «найдено / удалено / пропущено».
- **Удаление идемпотентно:** 404 пропускается, прочие ошибки валят шаг.
- **В описании действия** зафиксировано, как выбирается путь и что `github.token`
  удаляет версии только у пакета, привязанного к репозиторию.
- Исправлена опечатка в имени действия: `Docrer` → `Docker`.

## Решения, которые из диффа не выводятся

- Тип владельца выясняется в рантайме, а не задаётся входом: значение
  однозначно выводится из репозитория, и лишний вход был бы ещё одним местом,
  где можно ошибиться.
- Префикс `sha-` вынесен в переменную `TAG_PREFIX`, но входом пока не стал —
  параметризация идёт отдельной задачей, здесь это только подготовка места.

## Что намеренно не вошло

Имя пакета по-прежнему выводится из `GITHUB_REPOSITORY`, тогда как образ
публикуется под настраиваемым входом `image-name`. При кастомном `image-name`
чистка промахнётся мимо пакета. Это параметризация, а не дефект обращения
к API, — идёт отдельной задачей вместе с остальными захардкоженными значениями.

## Проверка

Локально скрипт прогнан с заглушками `gh` и `jq` (`jq` в системе нет),
шесть сценариев:

| сценарий | ожидание | результат |
| --- | --- | --- |
| dry-run, у версии два `sha-`-тега | один кандидат, ничего не удаляется | ок |
| удаление, у одной версии 404 | прогон успешен, счётчики 2 / 1 | ок |
| удаление, 403 | прогон падает | ок |
| владелец — пользователь | путь `users/…` | ок |
| тип владельца не получен / неизвестен | падение с сообщением | ок |
| список версий недоступен | падение с сообщением | ок |

Отдельно подтверждено на живом API, что `gh --jq` печатает компактный
однострочный JSON, — на этом держится построчное чтение в цикле.

Чего проверка не покрывает: **сам jq-фильтр не исполнялся**, в тесте `jq`
заглушен. Семантика `any(generator; condition)`, `startswith`
и `fromdateiso8601` сверена по руководству jq, но фактический прогон фильтра
будет только у потребителя.

На потребителе: прогон с `show-only: true` должен вывести список версий,
а не 404. Сверить с
`gh api orgs/nii-energomash/packages/container/kdepa-spa/versions`
(нужен токен со `read:packages`).

Closes #10
