### PR TITLE
fix: gitea-воркфлоу используют gitea-вариант настройки реестров

### DIFF
--- a/.gitea/workflows/npm-ci-for-mirror.yml
+++ b/.gitea/workflows/npm-ci-for-mirror.yml
@@ -30,6 +30,11 @@ on:
           Массив строк, разделенный переносом строки, и содержащий scope и адрес регистра в формате
           @\<scope\>:registry=\<uri\>. Например: @username:registry=https://192.168.100.252:3000/api/packages/username/npm/
 
+    secrets:
+      node-auth-token:
+        required: false
+        description: Токен для приватных NPM регистров
+
 jobs:
   reusable-ci:
     runs-on: ubuntu-latest
@@ -54,9 +59,10 @@ jobs:
           cache: npm
 
       - name: 📝 Configure npm registries
-        uses: https://192.168.100.252:3000/usov-andrey/automation/.github/actions/npm-registries-configure@master
+        uses: https://192.168.100.252:3000/usov-andrey/automation/.gitea/actions/npm-registries-configure@master
         with:
           npm-scopes-with-registers: ${{ inputs.npm-scopes-with-registers }}
+          node-auth-token: ${{ secrets.node-auth-token }}
 
       # ПРИМЕЧАНИЕ:
       # Файл package-lock.json удаляется намеренно.

--- a/.gitea/workflows/npm-ci.yml
+++ b/.gitea/workflows/npm-ci.yml
@@ -62,7 +62,7 @@ jobs:
           cache: npm
 
       - name: 📝 Configure npm registries
-        uses: https://192.168.100.252:3000/usov-andrey/automation/.github/actions/npm-registries-configure@master
+        uses: https://192.168.100.252:3000/usov-andrey/automation/.gitea/actions/npm-registries-configure@master
         with:
           npm-scopes-with-registers: ${{ inputs.npm-scopes-with-registers }}
           node-auth-token: ${{ secrets.node-auth-token }}


### PR DESCRIPTION
Два CI-воркфлоу в `.gitea/workflows` подключали действие настройки npm-реестров
из каталога `.github`, хотя рядом лежит gitea-вариант того же действия.
`npm-package-publish.yml` при этом ссылался правильно — то есть это недосмотр,
а не замысел.

github-копия дописывает строку токена жёстко для `npm.pkg.github.com`
и ни для чего больше: в Gitea токен уходил не на тот хост. Плюс в ней нет
`strict-ssl=false`, без которого HTTPS на инстанс с самоподписанным
сертификатом не проходит вовсе.

## Что вошло

- **`npm-ci.yml` и `npm-ci-for-mirror.yml`** переведены на
  `.gitea/actions/npm-registries-configure`.
- **В `npm-ci-for-mirror.yml` добавлен необязательный секрет
  `node-auth-token`** и проброс в действие, по образцу `npm-ci.yml`. Раньше
  блока `secrets:` там не было вовсе, хотя workflow рассчитан именно
  на зеркальные пакеты из реестра Gitea: он намеренно удаляет
  `package-lock.json` и ставит зависимости заново.

`npm-package-publish.yml` не тронут. Нейтральные действия — `resolve-context`,
`validate-tag-format`, `validate-ref-on-master`,
`npm-setup-package-version-from-tag` — остаются в `.github`: разницы между
площадками у них нет, отдельной gitea-копии не существует.

## Совместимость

Секрет объявлен `required: false`. Если вызывающий его не передаёт, значение
пустое и скрипт строку токена не пишет — поведение прежнее.

## Что намеренно не вошло

Хардкод `192.168.100.252:3000` и `usov-andrey` в строках `uses:`.
Параметризовать `uses:` нельзя: выражения в этом ключе не раскрываются.
Отвязка от адреса идёт отдельной задачей вместе с остальной параметризацией.

## Проверка

- Все три воркфлоу в `.gitea/workflows` разбираются YAML-парсером и объявляют
  `node-auth-token`; `git ls-files --eol` — LF.
- На Gitea: прогон `npm-ci` с приватной зависимостью. В `~/.npmrc` должна
  попасть строка токена для хоста Gitea, а не для `npm.pkg.github.com`,
  и строка `strict-ssl=false`. Установка зависимостей проходит.

Closes #12
