### PR TITLE
fix: токен npm пишется для каждого переданного реестра

### DIFF
--- a/.gitea/actions/npm-registries-configure/registries-configure.sh
+++ b/.gitea/actions/npm-registries-configure/registries-configure.sh
@@ -1,42 +1,59 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-echo "Generating ~/.npmrc"
-: > ~/.npmrc
+NPMRC="${HOME}/.npmrc"
+
+echo "Generating ${NPMRC}"
+: >"$NPMRC"
+
+# Команды раннера вида ::add-mask:: в Gitea Actions не документированы.
+# Если раннер такую строку не разберёт, она уйдёт в лог вместе с токеном,
+# поэтому здесь маскировки нет — токен просто нигде не печатается.
 
 declare -A REGISTRIES=()
 
 while IFS= read -r registry_src; do
     [ -z "$registry_src" ] && continue
 
-    echo "$registry_src" >> ~/.npmrc
+    echo "$registry_src" >>"$NPMRC"
 
-    if [ -n "${NODE_AUTH_TOKEN:-}" ]; then
-        registry_url="${registry_src#*:registry=}"
+    # Строка без ':registry=' попадает в ~/.npmrc как есть, но хост из неё
+    # не выводится: ключом стала бы вся строка целиком.
+    case "$registry_src" in
+        *:registry=*) ;;
+        *) continue ;;
+    esac
 
-        registry_no_proto="${registry_url#http://}"
-        registry_no_proto="${registry_no_proto#https://}"
+    registry_key="${registry_src#*:registry=}"
+    registry_key="${registry_key#http://}"
+    registry_key="${registry_key#https://}"
 
-        REGISTRIES["$registry_no_proto"]=1
-    fi
+    # npm сопоставляет ключ вида //host[/path]/:_authToken= — с ровно одним
+    # завершающим слэшем. Адрес реестра пишут и со слэшем, и без него.
+    registry_key="${registry_key%/}/"
 
+    REGISTRIES["$registry_key"]=1
 done <<EOF
 ${SCOPES_WITH_REGISTERS}
 EOF
 
-if [ -n "${NODE_AUTH_TOKEN:-}" ]; then
-    for registry in "${!REGISTRIES[@]}"; do
-        echo "//${registry}:_authToken=${NODE_AUTH_TOKEN}" >> ~/.npmrc
+if [ -z "${NODE_AUTH_TOKEN:-}" ]; then
+    echo "🔓 NODE_AUTH_TOKEN не задан, строки с токеном не добавлены"
+elif [ "${#REGISTRIES[@]}" -eq 0 ]; then
+    echo "🔓 Ни одной строки с ':registry=' не передано, токен добавлять некуда"
+else
+    for registry_key in "${!REGISTRIES[@]}"; do
+        echo "//${registry_key}:_authToken=${NODE_AUTH_TOKEN}" >>"$NPMRC"
     done
     echo "🔑 NPM токен добавлен для ${#REGISTRIES[@]} registry"
-else
-    echo "🔓 NODE_AUTH_TOKEN не задан, строка с токеном не добавлена"
 fi
 
-echo "strict-ssl=false" >> ~/.npmrc
+echo "strict-ssl=false" >>"$NPMRC"
+
+echo "📝 Конфигурация NPM сохранена в ${NPMRC}"
 
 echo ""
-echo "📄 Содержимое ~/.npmrc:"
+echo "📄 Содержимое ${NPMRC} (значение токена скрыто):"
 echo "----------------------------------------"
-cat ~/.npmrc
+sed -E 's/(_authToken=).*/\1***/' "$NPMRC"
 echo "----------------------------------------"

--- a/.github/actions/npm-registries-configure/registries-configure.sh
+++ b/.github/actions/npm-registries-configure/registries-configure.sh
@@ -1,27 +1,59 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-echo "Generating ~/.npmrc"
-: > ~/.npmrc
+NPMRC="${HOME}/.npmrc"
+
+echo "Generating ${NPMRC}"
+: >"$NPMRC"
+
+if [ -n "${NODE_AUTH_TOKEN:-}" ]; then
+    # Раннер маскирует только значения из secrets.*, а сюда токен приходит
+    # входом действия и может быть передан откуда угодно.
+    echo "::add-mask::${NODE_AUTH_TOKEN}"
+fi
+
+declare -A REGISTRIES=()
 
 while IFS= read -r registry_src; do
     [ -z "$registry_src" ] && continue
-    echo "$registry_src" >> ~/.npmrc
+
+    echo "$registry_src" >>"$NPMRC"
+
+    # Строка без ':registry=' попадает в ~/.npmrc как есть, но хост из неё
+    # не выводится: ключом стала бы вся строка целиком.
+    case "$registry_src" in
+        *:registry=*) ;;
+        *) continue ;;
+    esac
+
+    registry_key="${registry_src#*:registry=}"
+    registry_key="${registry_key#http://}"
+    registry_key="${registry_key#https://}"
+
+    # npm сопоставляет ключ вида //host[/path]/:_authToken= — с ровно одним
+    # завершающим слэшем. Адрес реестра пишут и со слэшем, и без него.
+    registry_key="${registry_key%/}/"
+
+    REGISTRIES["$registry_key"]=1
 done <<EOF
 ${SCOPES_WITH_REGISTERS}
 EOF
 
-if [ -n "${NODE_AUTH_TOKEN:-}" ]; then
-    echo "//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}" >> ~/.npmrc
-    echo "🔑 NPM токен добавлен в конфигурацию"
+if [ -z "${NODE_AUTH_TOKEN:-}" ]; then
+    echo "🔓 NODE_AUTH_TOKEN не задан, строки с токеном не добавлены"
+elif [ "${#REGISTRIES[@]}" -eq 0 ]; then
+    echo "🔓 Ни одной строки с ':registry=' не передано, токен добавлять некуда"
 else
-    echo "🔓 NODE_AUTH_TOKEN не задан, строка с токеном не добавлена"
+    for registry_key in "${!REGISTRIES[@]}"; do
+        echo "//${registry_key}:_authToken=${NODE_AUTH_TOKEN}" >>"$NPMRC"
+    done
+    echo "🔑 NPM токен добавлен для ${#REGISTRIES[@]} registry"
 fi
 
-echo "📝 Конфигурация NPM сохранена в ~/.npmrc"
+echo "📝 Конфигурация NPM сохранена в ${NPMRC}"
 
 echo ""
-echo "📄 Содержимое ~/.npmrc:"
+echo "📄 Содержимое ${NPMRC} (значение токена скрыто):"
 echo "----------------------------------------"
-cat ~/.npmrc
+sed -E 's/(_authToken=).*/\1***/' "$NPMRC"
 echo "----------------------------------------"


### PR DESCRIPTION
github-копия скрипта всегда писала строку токена для одного захардкоженного
хоста, хотя вход `npm-scopes-with-registers` позволяет маршрутизировать scope
на любой реестр. Плюс обе копии печатали `~/.npmrc` целиком, вместе со строкой
`_authToken`.

## Что вошло

- **Хосты выводятся из переданных строк scope** вместо захардкоженного
  `npm.pkg.github.com`. Дубликаты схлопываются: два scope на одном реестре
  дают одну строку токена.
- **Ключ реестра нормализуется по завершающему слэшу.** По документации npm
  ключ имеет вид `//host[/path]/:_authToken=`. Прежний вывод в gitea-копии
  снимал протокол и на этом останавливался: для `https://npm.pkg.github.com`
  получилось бы `//npm.pkg.github.com:_authToken=`, чего npm не сопоставит.
  В gitea-примерах адреса записаны со слэшем на конце, поэтому там совпадало
  случайно.
- **Строка без `:registry=`** пишется в `~/.npmrc` как есть, но хост из неё
  не выводится — раньше ключом стала бы вся строка целиком.
- **`~/.npmrc` печатается со скрытым значением `_authToken`.**
- **В github-копию добавлен `::add-mask::`** для токена: раннер маскирует
  только значения из `secrets.*`, а сюда токен приходит входом действия.

## Решения, которые из диффа не выводятся

`::add-mask::` есть только в github-копии. Поддержка команд раннера в Gitea
Actions не документирована, и если раннер строку не разберёт, она уйдёт в лог
вместе с токеном — лечение оказалось бы хуже болезни. Основная защита,
не печатать токен, работает на обеих площадках.

Кроме этой строки копии теперь отличаются только `strict-ssl=false`
в gitea-варианте.

## Совместимость

Регресса у существующих потребителей нет:

- `@scope:registry=https://npm.pkg.github.com` → `//npm.pkg.github.com/:_authToken=` —
  ровно та строка, что была захардкожена;
- `@scope:registry=https://<gitea>/api/packages/<owner>/npm/` → ключ не изменился.

## Проверка

Оба скрипта прогнаны локально (нужны только bash и sed), семь случаев:

| вход | ожидание | результат |
| --- | --- | --- |
| github-адрес без слэша на конце | ключ `//npm.pkg.github.com/:` | ок |
| два scope на одном хосте | одна строка токена | ок |
| gitea-адрес с путём и слэшем | ключ не изменился | ок |
| `http` и `https` на разных хостах | две строки токена | ок |
| строка без `:registry=` | записана, ключа нет | ок |
| токен не задан | строк токена нет | ок |
| вход только из не-registry строки | строк токена нет | ок |

Ни в одном случае токен не попадает в видимый вывод (строка `::add-mask::`
перехватывается раннером и в лог не выводится).

На потребителе: прогон CI — в логе шага настройки реестров строк с токеном
быть не должно, `npm ci` при этом проходит.

Closes #14
