### PR TITLE
fix: входы действий передаются через env, а не подстановкой

### DIFF
--- a/.github/actions/npm-setup-package-version-from-tag/action.yml
+++ b/.github/actions/npm-setup-package-version-from-tag/action.yml
@@ -23,8 +23,14 @@ runs:
       id: version-tag
       shell: bash
       if: inputs.tag != ''
+      # Значение приходит переменной окружения, а не подстановкой в текст
+      # скрипта: подставленное значение стало бы частью кода.
+      env:
+        INPUT_TAG: ${{ inputs.tag }}
       run: |
-        VERSION="${{ inputs.tag }}"
+        set -euo pipefail
+
+        VERSION="$INPUT_TAG"
         VERSION="${VERSION#v}"
 
         npm version "$VERSION" \
@@ -32,13 +38,15 @@ runs:
           --allow-same-version
 
         echo "📌 Установлена версия npm пакета из git-тега: ${VERSION}"
-        echo "version=${VERSION}" >> $GITHUB_OUTPUT
+        printf 'version=%s\n' "$VERSION" >>"$GITHUB_OUTPUT"
 
     - name: Set package version from commit hash
       id: version-hash
       shell: bash
       if: inputs.tag == ''
       run: |
+        set -euo pipefail
+
         EMPTY_VERSION="0.0.0"
         HASH=$(git rev-parse --short HEAD)
 
@@ -49,12 +57,19 @@ runs:
           --allow-same-version
 
         echo "📌 Установлена версия npm пакета из hash коммита: ${VERSION}"
-        echo "version=${VERSION}" >> $GITHUB_OUTPUT
+        printf 'version=%s\n' "$VERSION" >>"$GITHUB_OUTPUT"
 
     - name: Output final version
       id: version-final
       shell: bash
+      # Значения приходят переменными окружения, а не подстановкой в текст
+      # скрипта: подставленное значение стало бы частью кода.
+      env:
+        VERSION_FROM_TAG: ${{ steps.version-tag.outputs.version }}
+        VERSION_FROM_HASH: ${{ steps.version-hash.outputs.version }}
       run: |
-        FINAL_VERSION="${{ steps.version-tag.outputs.version || steps.version-hash.outputs.version }}"
+        set -euo pipefail
+
+        FINAL_VERSION="${VERSION_FROM_TAG:-$VERSION_FROM_HASH}"
         echo "✅ Final package version: ${FINAL_VERSION}"
-        echo "package-version=${FINAL_VERSION}" >> $GITHUB_OUTPUT
+        printf 'package-version=%s\n' "$FINAL_VERSION" >>"$GITHUB_OUTPUT"

--- a/.github/actions/resolve-context/action.yml
+++ b/.github/actions/resolve-context/action.yml
@@ -53,33 +53,49 @@ runs:
     - name: 🔍 Resolve context
       id: resolve
       shell: bash
+      # Значения приходят переменными окружения, а не подстановкой в текст
+      # скрипта: подставленное значение стало бы частью кода.
+      env:
+        INPUT_MODE: ${{ inputs.mode }}
+        INPUT_TAG: ${{ inputs.tag }}
+        INPUT_REGISTRY: ${{ inputs.registry }}
+        INPUT_IMAGE_NAME: ${{ inputs.image-name }}
+        COMMIT_SHA: ${{ github.sha }}
       run: |
         set -euo pipefail
 
-        REPO="${{ inputs.registry }}/${{ inputs.image-name }}"
-        MODE="${{ inputs.mode }}"
+        # Перенос строки в значении добавил бы в $GITHUB_OUTPUT лишнюю
+        # строку 'имя=значение', то есть подменил бы произвольный выход шага.
+        set_output() {
+          if [[ "$2" == *$'\n'* ]]; then
+            echo "❌ Значение '$1' содержит перенос строки"
+            exit 1
+          fi
+          printf '%s=%s\n' "$1" "$2" >>"$GITHUB_OUTPUT"
+        }
 
-        if [[ "$MODE" == "feature" ]]; then
-          COMMIT_HASH="${{ github.sha }}"
+        REPO="${INPUT_REGISTRY}/${INPUT_IMAGE_NAME}"
+
+        if [[ "$INPUT_MODE" == "feature" ]]; then
           REF="${GITHUB_REF}"
-          TAG="sha-$COMMIT_HASH"
+          TAG="sha-${COMMIT_SHA}"
           VERSION=""
           IMAGE_REFERENCES="$REPO:$TAG"
 
-        elif [[ "$MODE" == "release" ]]; then
+        elif [[ "$INPUT_MODE" == "release" ]]; then
           REF="${GITHUB_REF}"
           TAG="${GITHUB_REF#refs/tags/}"
           VERSION="${GITHUB_REF#refs/tags/v}"
           IMAGE_REFERENCES="$REPO:$TAG,$REPO:latest"
 
-        elif [[ "$MODE" == "rebuild" ]]; then
-          REF="refs/tags/${{ inputs.tag }}"
-          TAG="${{ inputs.tag }}"
+        elif [[ "$INPUT_MODE" == "rebuild" ]]; then
+          REF="refs/tags/${INPUT_TAG}"
+          TAG="${INPUT_TAG}"
           VERSION="${TAG#v}"
           IMAGE_REFERENCES="$REPO:$TAG"
 
         else
-          echo "❌ Неизвестный режим mode: $MODE"
+          echo "❌ Неизвестный режим mode: $INPUT_MODE"
           exit 1
         fi
 
@@ -90,7 +106,7 @@ runs:
         echo "  image-references:"
         echo "$IMAGE_REFERENCES" | tr ',' '\n' | sed 's/^/    - /'
 
-        echo "ref=$REF" >> $GITHUB_OUTPUT
-        echo "version=$VERSION" >> $GITHUB_OUTPUT
-        echo "tag=$TAG" >> $GITHUB_OUTPUT
-        echo "image-references=$IMAGE_REFERENCES" >> $GITHUB_OUTPUT
+        set_output ref "$REF"
+        set_output version "$VERSION"
+        set_output tag "$TAG"
+        set_output image-references "$IMAGE_REFERENCES"

--- a/.github/actions/resolve-tag-from-ref/action.yml
+++ b/.github/actions/resolve-tag-from-ref/action.yml
@@ -19,10 +19,15 @@ runs:
     - name: 🏷️ Resolve tag from ref
       id: resolve
       shell: bash
+      # Значения приходят переменными окружения, а не подстановкой в текст
+      # скрипта: подставленное значение стало бы частью кода.
+      env:
+        INPUT_REF: ${{ inputs.ref }}
+        DEFAULT_REF: ${{ github.ref }}
       run: |
         set -euo pipefail
 
-        REF="${{ inputs.ref != '' && inputs.ref || github.ref }}"
+        REF="${INPUT_REF:-$DEFAULT_REF}"
 
         if [ -z "${REF}" ]; then
           echo "❌ Ошибка: ref не определён"
@@ -36,5 +41,12 @@ runs:
           exit 1
         fi
 
-        echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+        # Перенос строки в значении добавил бы в $GITHUB_OUTPUT лишнюю
+        # строку 'имя=значение', то есть подменил бы произвольный выход шага.
+        if [[ "$TAG" == *$'\n'* ]]; then
+          echo "❌ Значение тега содержит перенос строки"
+          exit 1
+        fi
+
+        printf 'tag=%s\n' "$TAG" >>"$GITHUB_OUTPUT"
         echo "📌 Тег из ref: ${TAG}"

--- a/.github/actions/resolve-tag-to-ref/action.yml
+++ b/.github/actions/resolve-tag-to-ref/action.yml
@@ -24,10 +24,14 @@ runs:
     - name: ➡️ Resolve tag to ref
       id: resolve
       shell: bash
+      # Значение приходит переменной окружения, а не подстановкой в текст
+      # скрипта: подставленное значение стало бы частью кода.
+      env:
+        INPUT_TAG: ${{ inputs.tag }}
       run: |
         set -euo pipefail
 
-        TAG="${{ inputs.tag }}"
+        TAG="$INPUT_TAG"
         echo "🔎 Input tag: $TAG"
 
         REF="refs/tags/$TAG"
@@ -42,5 +46,12 @@ runs:
           exit 1
         fi
 
-        echo "ref=${REF}" >> $GITHUB_OUTPUT
+        # Перенос строки в значении добавил бы в $GITHUB_OUTPUT лишнюю
+        # строку 'имя=значение', то есть подменил бы произвольный выход шага.
+        if [[ "$REF" == *$'\n'* ]]; then
+          echo "❌ Значение ref содержит перенос строки"
+          exit 1
+        fi
+
+        printf 'ref=%s\n' "$REF" >>"$GITHUB_OUTPUT"
         echo "📌 Full ref: $REF"

--- a/.github/actions/validate-ref-on-master/action.yml
+++ b/.github/actions/validate-ref-on-master/action.yml
@@ -13,10 +13,14 @@ runs:
   steps:
     - name: 🔍 Validate ref on master
       shell: bash
+      # Значение приходит переменной окружения, а не подстановкой в текст
+      # скрипта: подставленное значение стало бы частью кода.
+      env:
+        INPUT_REF: ${{ inputs.ref }}
       run: |
         set -euo pipefail
 
-        REF="${{ inputs.ref }}"
+        REF="$INPUT_REF"
         echo "🔎 Checking ref: $REF"
 
         if ! REF_COMMIT="$(git rev-parse "$REF" 2>/dev/null)"; then

--- a/.github/actions/validate-tag-format/action.yml
+++ b/.github/actions/validate-tag-format/action.yml
@@ -13,10 +13,14 @@ runs:
   steps:
     - name: 🔍 Validate git-tag
       shell: bash
+      # Значение приходит переменной окружения, а не подстановкой в текст
+      # скрипта: подставленное значение стало бы частью кода.
+      env:
+        INPUT_TAG: ${{ inputs.tag }}
       run: |
         set -euo pipefail
 
-        TAG="${{ inputs.tag }}"
+        TAG="$INPUT_TAG"
 
         echo "🔎 Input tag: $TAG"
 


### PR DESCRIPTION
Шесть composite actions подставляли значения выражений прямо в тело bash.
Подстановка происходит до запуска оболочки: значение попадает в текст скрипта,
а не в переменную, и значение с кавычкой и `;` выполняется как код.

## Что вошло

- **Значения передаются блоком `env:` шага** и читаются как `"$VAR"`.
  Затронуты `resolve-context`, `resolve-tag-from-ref`, `resolve-tag-to-ref`,
  `validate-ref-on-master`, `validate-tag-format`,
  `npm-setup-package-version-from-tag`.
- **Перед записью в `$GITHUB_OUTPUT` отвергается значение с переносом
  строки.** Иначе такое значение добавило бы в файл лишнюю строку
  `имя=значение`, то есть подменило бы произвольный выход шага.
- **В шагах установки версии пакета включён `set -euo pipefail`** — рядом
  с соседними шагами его не было.

`resolve-tag-from-ref` в исходном перечне не значился, но подстановка там
ровно та же — оставлять один экземпляр дефекта смысла нет.

## Что осталось и почему

Внутри `run:` сохранились подстановки `${{ github.action_path }}`
в `docker-cleanup` и обеих копиях `npm-registries-configure`. Это путь,
который подставляет раннер, а не пользовательский ввод, и штатный способ
сослаться на каталог действия.

## Что намеренно не вошло

Относительный `uses: ./.github/actions/validate-tag-format` внутри
`resolve-tag-to-ref` — он не резолвится у внешнего потребителя. Отдельная
задача; здесь правился только bash-шаг того же файла.

## Проверка

Скрипты вытащены из YAML и прогнаны вживую:

| сценарий | ожидание | результат |
| --- | --- | --- |
| `resolve-context`, режимы `feature` / `release` / `rebuild` | выходы как прежде | ок |
| `resolve-context`, неизвестный режим | падение | ок |
| тег `v1.0.0"; touch PWNED; #`, **прежняя** форма скрипта | файл `PWNED` создаётся | воспроизведено |
| тот же тег, новая форма | значение остаётся данными, `PWNED` нет | ок |
| тег с переносом строки и дописанным `ref=evil` | падение до записи, `$GITHUB_OUTPUT` пуст | ок |
| `validate-tag-format`: `v1.2.3` / `v1.2` / тег с командой | пропуск / отказ / отказ | ок |

Отдельно проверено, что подстановок внутри `run:` в затронутых действиях
не осталось. Все `action.yml` разбираются YAML-парсером, `git ls-files --eol` — LF.

На потребителе: `republish-with-tag-manually` с валидным тегом — успех;
с тегом `v1.2` — падение на валидации формата.

Closes #16
