### PR TITLE
fix: resolve-tag-to-ref не зависит от каталога потребителя

### DIFF
--- a/.github/actions/resolve-tag-to-ref/action.yml
+++ b/.github/actions/resolve-tag-to-ref/action.yml
@@ -1,12 +1,12 @@
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 
-name: Resolve tag to ref (НЕ НУЖЕН?)
+name: Resolve tag to ref
 description: Получение git-ref по переданному git-тегу (используется при ручной публикации по тегу)
 
 inputs:
   tag:
     required: true
-    description: Тег в фомате v*.*.*
+    description: Тег в формате v*.*.*
 
 outputs:
   ref:
@@ -16,11 +16,6 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: 🔍 Validate tag format
-      uses: ./.github/actions/validate-tag-format
-      with:
-        tag: ${{ inputs.tag }}
-
     - name: ➡️ Resolve tag to ref
       id: resolve
       shell: bash
@@ -33,6 +28,17 @@ runs:
 
         TAG="$INPUT_TAG"
         echo "🔎 Input tag: $TAG"
+
+        # Проверка намеренно дублирует действие validate-tag-format.
+        # Вызвать его отсюда нечем: относительный путь './' внутри composite
+        # action резолвится в рабочем каталоге потребителя, а ссылка на
+        # собственный репозиторий '$/' недоступна вне github.com — каталог
+        # .github/actions подключается и с раннера Gitea.
+        if ! [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          echo "❌ Invalid tag format: $TAG"
+          echo "Expected: vMAJOR.MINOR.PATCH (e.g. v1.2.3)"
+          exit 1
+        fi
 
         REF="refs/tags/$TAG"
 


### PR DESCRIPTION
`resolve-tag-to-ref` первым шагом вызывал соседнее действие относительным
путём `./.github/actions/validate-tag-format`. Относительный путь резолвится
в репозитории рабочего процесса, то есть в рабочем каталоге потребителя,
а не в репозитории самого действия — у любого внешнего вызова он указывал
в чужой репозиторий.

## Что вошло

- **Вложенный вызов убран**, проверка формата тега внесена в шаг разбора.
- **Из имени действия снята пометка «(НЕ НУЖЕН?)»** — вопрос был про удаление,
  решение принято: оставить и починить.
- Опечатка в описании входа: «в фомате» → «в формате».

## Почему дублирование, а не ссылка на собственный репозиторий

GitHub документирует `uses: $/.github/actions/validate-tag-format` — ссылку
на репозиторий, содержащий composite action, на текущем коммите, без checkout
и без суффикса `@ref`. Для github.com это было бы идиоматичнее.

Там же сказано: «The `$/` syntax is not available in GitHub Enterprise Server».
Каталог `.github/actions` в этом репозитории де-факто общий для обеих площадок —
`.gitea/workflows/npm-package-publish.yml` подключает оттуда `resolve-context`,
`validate-tag-format`, `validate-ref-on-master`
и `npm-setup-package-version-from-tag`. Синтаксис, недоступный даже на GHES,
почти наверняка не поддержан и раннером Gitea, а `$/` сделал бы действие
пригодным только для github.com.

Поэтому регулярное выражение продублировано с комментарием прямо в шаге.
Если gitea-совместимость этого действия окажется не нужна, возврат к `$/` —
правка на одну строку.

## Проверка

Собран временный репозиторий с тегами `v1.0.0` и `v1.2.3`, скрипт действия
прогнан вживую:

| вход | ожидание | результат |
| --- | --- | --- |
| `v1.2.3` | `ref=refs/tags/v1.2.3` | ок |
| `v9.9.9` | отказ, список доступных тегов | ок |
| `v1.2` | отказ по формату | ок |
| `v1.0.0"; touch PWNED; #` | отказ по формату, файл не создаётся | ок |

В действии остался ровно один шаг, `uses:` в нём нет. `git ls-files --eol` — LF.

## Побочный вывод

`$/` внутри воркфлоу документация описывает только со стороны вызывающего;
что он делает внутри уже вызванного переиспользуемого workflow — не оговорено.
Значит на подготовку релизной ветки это не переносится: внутренние пины
`@master` в переиспользуемых воркфлоу придётся переписывать вручную.

Closes #18
