### PR TITLE
chore: пины сторонних экшенов подняты до текущих мажоров

### DIFF
--- a/.gitea/workflows/npm-ci-for-mirror.yml
+++ b/.gitea/workflows/npm-ci-for-mirror.yml
@@ -47,13 +47,13 @@ jobs:
 
     steps:
       - name: 🛒 Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           ref: ${{ inputs.ref != '' && inputs.ref || github.ref }}
 
       - name: ✨ Setup Node.js (version ${{ inputs.node-version }})
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ inputs.node-version }}
           cache: npm

--- a/.gitea/workflows/npm-ci.yml
+++ b/.gitea/workflows/npm-ci.yml
@@ -50,13 +50,13 @@ jobs:
 
     steps:
       - name: 🛒 Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           ref: ${{ inputs.ref != '' && inputs.ref || github.ref }}
 
       - name: ✨ Setup Node.js (version ${{ inputs.node-version }})
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ inputs.node-version }}
           cache: npm

--- a/.gitea/workflows/npm-package-publish.yml
+++ b/.gitea/workflows/npm-package-publish.yml
@@ -60,7 +60,7 @@ jobs:
           tag: ${{ inputs.tag }}
 
       - name: 🛒 Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           ref: ${{ steps.ctx.outputs.ref }}
@@ -78,9 +78,13 @@ jobs:
           ref: ${{ steps.ctx.outputs.ref }}
 
       - name: ✨ Setup Node.js (version ${{ inputs.node-version }})
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ inputs.node-version }}
+          # setup-node начиная с v5 сам включает кеш npm, если в package.json
+          # есть поле packageManager. В публикации кеша не было — это лишняя
+          # переменная в шаге, от которого зависит содержимое пакета.
+          package-manager-cache: false
 
       - name: 📝 Configure NPM registries
         uses: https://192.168.100.252:3000/usov-andrey/automation/.gitea/actions/npm-registries-configure@master

--- a/.github/workflows/npm-ci.yml
+++ b/.github/workflows/npm-ci.yml
@@ -54,13 +54,13 @@ jobs:
 
     steps:
       - name: 🛒 Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           ref: ${{ inputs.ref != '' && inputs.ref || github.ref }}
 
       - name: ✨ Setup Node.js (version ${{ inputs.node-version }})
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ inputs.node-version }}
           cache: npm
@@ -89,7 +89,7 @@ jobs:
 
       - name: 📦 Upload artifact
         if: ${{ inputs.publish-artifact }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: build
           path: dist/

--- a/.github/workflows/npm-docker-publish.yml
+++ b/.github/workflows/npm-docker-publish.yml
@@ -76,7 +76,7 @@ jobs:
           image-name: ${{ inputs.image-name }}
 
       - name: 🛒 Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           ref: ${{ steps.ctx.outputs.ref }}
@@ -95,9 +95,13 @@ jobs:
           ref: ${{ steps.ctx.outputs.ref }}
 
       - name: ✨ Setup Node.js (version ${{ inputs.node-version }})
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ inputs.node-version }}
+          # setup-node начиная с v5 сам включает кеш npm, если в package.json
+          # есть поле packageManager. В публикации кеша не было — это лишняя
+          # переменная в шаге, от которого зависит содержимое образа.
+          package-manager-cache: false
 
       - name: 📝 Configure NPM registries
         uses: nii-energomash/automation/.github/actions/npm-registries-configure@master
@@ -127,14 +131,14 @@ jobs:
         run: npm run build
 
       - name: 🔐 Log in to container registry (${{ inputs.registry }})
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ inputs.registry }}
           username: ${{ github.actor }}
           password: ${{ secrets.docker-auth-token }}
 
       - name: 🐳 Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true

--- a/.github/workflows/npm-package-publish.yml
+++ b/.github/workflows/npm-package-publish.yml
@@ -58,7 +58,7 @@ jobs:
           tag: ${{ inputs.tag }}
 
       - name: 🛒 Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           ref: ${{ steps.ctx.outputs.ref }}
@@ -76,9 +76,13 @@ jobs:
           ref: ${{ steps.ctx.outputs.ref }}
 
       - name: ✨ Setup Node.js (version ${{ inputs.node-version }})
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ inputs.node-version }}
+          # setup-node начиная с v5 сам включает кеш npm, если в package.json
+          # есть поле packageManager. В публикации кеша не было — это лишняя
+          # переменная в шаге, от которого зависит содержимое пакета.
+          package-manager-cache: false
 
       - name: 📝 Configure NPM registries
         uses: nii-energomash/automation/.github/actions/npm-registries-configure@master


### PR DESCRIPTION
15 пинов сторонних экшенов в шести воркфлоу. Версии сверены по GitHub API
на момент правки, а не по таблице в issue.

| экшен | было | стало | `using` |
| --- | --- | --- | --- |
| `actions/checkout` | v4 | v7 (v7.0.1) | node20 → node24 |
| `actions/setup-node` | v4 | v7 (v7.0.0) | node20 → node24 |
| `actions/upload-artifact` | v4 | v7 (v7.0.1) | node20 → node24 |
| `docker/login-action` | v3 | v4 (v4.6.0) | node24 |
| `docker/build-push-action` | v5 | v7 (v7.3.0) | node16 → node24 |

Раннер Gitea обновлён и node24 держит, поэтому `.gitea/**` поднят вместе
с `.github/**`, без разделения на два PR.

## Что нашлось в release notes

- **`setup-node` v5, ломающее.** Появился автоматический кеш npm при наличии
  поля `packageManager` в `package.json`; v6 сузил его до npm. В трёх
  воркфлоу публикации кеша не было вовсе — добавлен
  `package-manager-cache: false`, поведение сохранено. В трёх CI-воркфлоу
  остаётся явный `cache: npm`, на него автокеш не влияет.
- **`checkout` v6.** Учётные данные переехали в отдельный файл. Вход
  `persist-credentials` на v7 на месте, умолчание `true`, описание прежнее —
  `git fetch --no-tags origin master` в `validate-ref-on-master` продолжит
  работать.
- **`checkout` v7.** Блокирует checkout форкового PR для `pull_request_target`
  и `workflow_run`. Эти триггеры здесь не используются, примеры сидят
  на обычном `pull_request`.
- **`build-push-action` v6.** По умолчанию включён build summary. v7 убрал
  устаревшие `DOCKER_BUILD_NO_SUMMARY` и `DOCKER_BUILD_EXPORT_RETENTION_DAYS` —
  они здесь не задаются.
- **`upload-artifact` v7.** Входы `name`, `path`, `retention-days` на месте;
  новый `archive` по умолчанию `true`, то есть архивирование как прежде.
- **`setup-node` v7.** Убран «dummy NODE_AUTH_TOKEN export». `registry-url`
  здесь не используется, `NODE_AUTH_TOKEN` задаётся явно в шаге публикации.

## Расхождение с текстом задачи

Issue требует сначала снять срез, потом поднимать пины, «иначе откатываться
будет некуда». Порядок изменён сознательно: срез уйдёт в релизную ветку уже
с поднятыми версиями. Состояние до подъёма остаётся достижимым по коммиту
`5a434d1`.

## Проверка

- Все шесть воркфлоу разбираются YAML-парсером; старых пинов в репозитории
  не осталось (проверено по всем `*.yml`, включая `examples/**`);
  `git ls-files --eol` — LF.
- Списки входов `checkout@v7`, `setup-node@v7` и `upload-artifact@v7`
  сверены с тем, что реально передаётся из воркфлоу.
- На потребителе: прогнать `npm-ci` и публикацию по тегу на обеих
  площадках — GitHub и Gitea.

Closes #7
