### PR TITLE
Вынести захардкоженные значения во входы

### DIFF
--- a/.gitea/actions/npm-registries-configure/action.yml
+++ b/.gitea/actions/npm-registries-configure/action.yml
@@ -23,6 +23,14 @@ inputs:
       Токен для аутентификации в NPM регистрах. По умолчанию используется github.token.
       Для использования PAT передайте: secrets.YOUR_TOKEN
 
+  strict-ssl:
+    type: string
+    required: false
+    default: "true"
+    description: >
+      Проверять сертификат регистра (true | false).
+      false требуется для регистров с самоподписанным сертификатом
+
 runs:
   using: composite
   steps:
@@ -34,3 +42,4 @@ runs:
       env:
         SCOPES_WITH_REGISTERS: ${{ inputs.npm-scopes-with-registers }}
         NODE_AUTH_TOKEN: ${{ inputs.node-auth-token }}
+        STRICT_SSL: ${{ inputs.strict-ssl }}

--- a/.gitea/actions/npm-registries-configure/registries-configure.sh
+++ b/.gitea/actions/npm-registries-configure/registries-configure.sh
@@ -2,6 +2,12 @@
 set -euo pipefail
 
 NPMRC="${HOME}/.npmrc"
+STRICT_SSL="${STRICT_SSL:-true}"
+
+if [ "$STRICT_SSL" != "true" ] && [ "$STRICT_SSL" != "false" ]; then
+    echo "❌ STRICT_SSL must be 'true' or 'false'"
+    exit 1
+fi
 
 echo "Generating ${NPMRC}"
 : >"$NPMRC"
@@ -48,7 +54,7 @@ else
     echo "🔑 NPM токен добавлен для ${#REGISTRIES[@]} registry"
 fi
 
-echo "strict-ssl=false" >>"$NPMRC"
+echo "strict-ssl=${STRICT_SSL}" >>"$NPMRC"
 
 echo "📝 Конфигурация NPM сохранена в ${NPMRC}"
 

--- a/.gitea/workflows/npm-ci-for-mirror.yml
+++ b/.gitea/workflows/npm-ci-for-mirror.yml
@@ -22,6 +22,24 @@ on:
         default: "20"
         description: Версия Node.js
 
+      lint-script:
+        required: false
+        type: string
+        default: lint
+        description: npm-скрипт проверки стиля. Пустое значение пропускает шаг
+
+      test-script:
+        required: false
+        type: string
+        default: test
+        description: npm-скрипт тестов. Пустое значение пропускает шаг
+
+      build-script:
+        required: false
+        type: string
+        default: build
+        description: npm-скрипт сборки. Пустое значение пропускает шаг
+
       npm-scopes-with-registers:
         type: string
         required: false
@@ -63,6 +81,7 @@ jobs:
         with:
           npm-scopes-with-registers: ${{ inputs.npm-scopes-with-registers }}
           node-auth-token: ${{ secrets.node-auth-token }}
+          strict-ssl: "false"
 
       # ПРИМЕЧАНИЕ:
       # Файл package-lock.json удаляется намеренно.
@@ -78,14 +97,25 @@ jobs:
           echo "⚠️  Reference build: npm install без использования package-lock.json"
           npm install --no-fund
 
+      # Имя скрипта приходит переменной окружения, а не подстановкой в текст
+      # команды: подставленное значение стало бы частью кода.
       - name: 📝 Lint
+        if: ${{ inputs.lint-script != '' }}
         shell: bash
-        run: npm run lint
+        env:
+          NPM_SCRIPT: ${{ inputs.lint-script }}
+        run: npm run "$NPM_SCRIPT"
 
       - name: 🧪 Tests
+        if: ${{ inputs.test-script != '' }}
         shell: bash
-        run: npm test
+        env:
+          NPM_SCRIPT: ${{ inputs.test-script }}
+        run: npm run "$NPM_SCRIPT"
 
       - name: 🛠️ Build
+        if: ${{ inputs.build-script != '' }}
         shell: bash
-        run: npm run build
+        env:
+          NPM_SCRIPT: ${{ inputs.build-script }}
+        run: npm run "$NPM_SCRIPT"

--- a/.gitea/workflows/npm-ci.yml
+++ b/.gitea/workflows/npm-ci.yml
@@ -19,6 +19,24 @@ on:
         default: "20"
         description: Версия Node.js
 
+      lint-script:
+        required: false
+        type: string
+        default: lint
+        description: npm-скрипт проверки стиля. Пустое значение пропускает шаг
+
+      test-script:
+        required: false
+        type: string
+        default: test
+        description: npm-скрипт тестов. Пустое значение пропускает шаг
+
+      build-script:
+        required: false
+        type: string
+        default: build
+        description: npm-скрипт сборки. Пустое значение пропускает шаг
+
       npm-scopes-with-registers:
         type: string
         required: false
@@ -66,19 +84,31 @@ jobs:
         with:
           npm-scopes-with-registers: ${{ inputs.npm-scopes-with-registers }}
           node-auth-token: ${{ secrets.node-auth-token }}
+          strict-ssl: "false"
 
       - name: 📦 Install dependencies
         shell: bash
         run: npm ci --no-fund
 
+      # Имя скрипта приходит переменной окружения, а не подстановкой в текст
+      # команды: подставленное значение стало бы частью кода.
       - name: 📝 Lint
+        if: ${{ inputs.lint-script != '' }}
         shell: bash
-        run: npm run lint
+        env:
+          NPM_SCRIPT: ${{ inputs.lint-script }}
+        run: npm run "$NPM_SCRIPT"
 
       - name: 🧪 Tests
+        if: ${{ inputs.test-script != '' }}
         shell: bash
-        run: npm test
+        env:
+          NPM_SCRIPT: ${{ inputs.test-script }}
+        run: npm run "$NPM_SCRIPT"
 
       - name: 🛠️ Build
+        if: ${{ inputs.build-script != '' }}
         shell: bash
-        run: npm run build
+        env:
+          NPM_SCRIPT: ${{ inputs.build-script }}
+        run: npm run "$NPM_SCRIPT"

--- a/.gitea/workflows/npm-package-publish.yml
+++ b/.gitea/workflows/npm-package-publish.yml
@@ -32,6 +32,30 @@ on:
         default: "20"
         description: Версия Node.js
 
+      base-branch:
+        required: false
+        type: string
+        default: master
+        description: Ветка, в которой должен находиться тег
+
+      lint-script:
+        required: false
+        type: string
+        default: lint
+        description: npm-скрипт проверки стиля. Пустое значение пропускает шаг
+
+      test-script:
+        required: false
+        type: string
+        default: test
+        description: npm-скрипт тестов. Пустое значение пропускает шаг
+
+      build-script:
+        required: false
+        type: string
+        default: build
+        description: npm-скрипт сборки. Пустое значение пропускает шаг
+
       npm-scopes-with-registers:
         type: string
         required: false
@@ -72,10 +96,11 @@ jobs:
         with:
           tag: ${{ steps.ctx.outputs.tag }}
 
-      - name: 🔍 Validate tag on master
+      - name: 🔍 Validate tag on base branch
         uses: https://192.168.100.252:3000/usov-andrey/automation/.github/actions/validate-ref-on-master@master
         with:
           ref: ${{ steps.ctx.outputs.ref }}
+          base-branch: ${{ inputs.base-branch }}
 
       - name: ✨ Setup Node.js (version ${{ inputs.node-version }})
         uses: actions/setup-node@v7
@@ -91,6 +116,7 @@ jobs:
         with:
           npm-scopes-with-registers: ${{ inputs.npm-scopes-with-registers }}
           node-auth-token: ${{ secrets.node-auth-token }}
+          strict-ssl: "false"
 
       - name: 📌 Set package version from tag
         uses: https://192.168.100.252:3000/usov-andrey/automation/.github/actions/npm-setup-package-version-from-tag@master
@@ -101,17 +127,28 @@ jobs:
         shell: bash
         run: npm ci --no-fund
 
+      # Имя скрипта приходит переменной окружения, а не подстановкой в текст
+      # команды: подставленное значение стало бы частью кода.
       - name: 📝 Lint
+        if: ${{ inputs.lint-script != '' }}
         shell: bash
-        run: npm run lint
+        env:
+          NPM_SCRIPT: ${{ inputs.lint-script }}
+        run: npm run "$NPM_SCRIPT"
 
       - name: 🧪 Tests
+        if: ${{ inputs.test-script != '' }}
         shell: bash
-        run: npm test
+        env:
+          NPM_SCRIPT: ${{ inputs.test-script }}
+        run: npm run "$NPM_SCRIPT"
 
       - name: 🛠️ Build
+        if: ${{ inputs.build-script != '' }}
         shell: bash
-        run: npm run build
+        env:
+          NPM_SCRIPT: ${{ inputs.build-script }}
+        run: npm run "$NPM_SCRIPT"
 
       - name: Publish to Github Registry with current Tag
         if: inputs.mode == 'release'

--- a/.github/actions/docker-cleanup/action.yml
+++ b/.github/actions/docker-cleanup/action.yml
@@ -3,7 +3,8 @@
 name: Docker cleanup
 description: >
   Удаление docker-образов.
-  Будут удалены образы, теги которых начинаются с 'sha-', и которые старше указанного возраста.
+  Будут удалены образы, теги которых начинаются с заданного префикса (по умолчанию 'sha-'),
+  и которые старше указанного возраста.
   Требуется permissions.packages.write и permissions.contents.read.
   Путь до пакета выбирается по типу владельца репозитория: у организации это
   /orgs/{org}/packages/..., у пользователя — /users/{username}/packages/...
@@ -26,6 +27,16 @@ inputs:
     default: false
     type: boolean
     description: "Только показать список (не удалять)"
+  technical-tag-prefix:
+    required: false
+    type: string
+    default: sha-
+    description: "Префикс технических тегов, по которому отбираются образы"
+  image-name:
+    required: false
+    type: string
+    default: ${{ github.repository }}
+    description: "Имя образа — то же, под которым образ публикуется"
 
 runs:
   using: composite
@@ -38,4 +49,6 @@ runs:
         DAYS_OLD: ${{ inputs.days-old }}
         HOURS_OLD: ${{ inputs.hours-old }}
         SHOW_ONLY: ${{ inputs.show-only }}
+        TAG_PREFIX: ${{ inputs.technical-tag-prefix }}
+        IMAGE_NAME: ${{ inputs.image-name }}
         GH_TOKEN: ${{ github.token }}

--- a/.github/actions/docker-cleanup/cleanup.sh
+++ b/.github/actions/docker-cleanup/cleanup.sh
@@ -15,18 +15,34 @@ set -euo pipefail
 DAYS_OLD="${DAYS_OLD:-0}"
 HOURS_OLD="${HOURS_OLD:-1}"
 SHOW_ONLY="${SHOW_ONLY:-false}"
-TAG_PREFIX="sha-"
+TAG_PREFIX="${TAG_PREFIX:-sha-}"
+IMAGE_NAME="${IMAGE_NAME:-$GITHUB_REPOSITORY}"
 
 #######################################
 # Derived values
 #######################################
 
 OWNER="$GITHUB_REPOSITORY_OWNER"
-REPO="${GITHUB_REPOSITORY#*/}"
+
+# Имя образа задаётся так же, как при публикации, то есть вместе с владельцем
+# (owner/name). В API пакетов владелец идёт отдельным сегментом пути, поэтому
+# префикс отрезается, а оставшиеся '/' кодируются: имя пакета — один сегмент.
+PACKAGE_NAME="${IMAGE_NAME#"${OWNER}/"}"
+PACKAGE_NAME="${PACKAGE_NAME//\//%2F}"
 
 #######################################
 # Validation
 #######################################
+
+if [[ -z "$PACKAGE_NAME" ]]; then
+  echo "❌ IMAGE_NAME не задаёт имя пакета: '${IMAGE_NAME}'"
+  exit 1
+fi
+
+if ! [[ "$TAG_PREFIX" =~ ^[A-Za-z0-9._-]+$ ]]; then
+  echo "❌ TAG_PREFIX must contain only [A-Za-z0-9._-]"
+  exit 1
+fi
 
 if ! [[ "$DAYS_OLD" =~ ^[0-9]+$ ]]; then
   echo "❌ DAYS_OLD must be a non-negative integer"
@@ -63,7 +79,7 @@ case "$OWNER_TYPE" in
     ;;
 esac
 
-PACKAGE_PATH="${OWNER_PATH}/packages/container/${REPO}"
+PACKAGE_PATH="${OWNER_PATH}/packages/container/${PACKAGE_NAME}"
 
 #######################################
 # Time calculation
@@ -73,7 +89,7 @@ CUTOFF_TS="$(date -d "${DAYS_OLD} days ${HOURS_OLD} hours ago" +%s)"
 
 echo "🧹 Docker cleanup"
 echo "Owner:        $OWNER ($OWNER_TYPE)"
-echo "Repository:   $REPO"
+echo "Image name:   $IMAGE_NAME"
 echo "Package path: $PACKAGE_PATH"
 echo "Tag prefix:   $TAG_PREFIX"
 echo "Days old:     $DAYS_OLD"

--- a/.github/actions/npm-registries-configure/action.yml
+++ b/.github/actions/npm-registries-configure/action.yml
@@ -23,6 +23,14 @@ inputs:
       Токен для аутентификации в NPM регистрах. По умолчанию используется github.token.
       Для использования PAT передайте: secrets.YOUR_TOKEN
 
+  strict-ssl:
+    type: string
+    required: false
+    default: "true"
+    description: >
+      Проверять сертификат регистра (true | false).
+      false требуется для регистров с самоподписанным сертификатом
+
 runs:
   using: composite
   steps:
@@ -34,3 +42,4 @@ runs:
       env:
         SCOPES_WITH_REGISTERS: ${{ inputs.npm-scopes-with-registers }}
         NODE_AUTH_TOKEN: ${{ inputs.node-auth-token }}
+        STRICT_SSL: ${{ inputs.strict-ssl }}

--- a/.github/actions/npm-registries-configure/registries-configure.sh
+++ b/.github/actions/npm-registries-configure/registries-configure.sh
@@ -2,6 +2,12 @@
 set -euo pipefail
 
 NPMRC="${HOME}/.npmrc"
+STRICT_SSL="${STRICT_SSL:-true}"
+
+if [ "$STRICT_SSL" != "true" ] && [ "$STRICT_SSL" != "false" ]; then
+    echo "❌ STRICT_SSL must be 'true' or 'false'"
+    exit 1
+fi
 
 echo "Generating ${NPMRC}"
 : >"$NPMRC"
@@ -49,6 +55,8 @@ else
     done
     echo "🔑 NPM токен добавлен для ${#REGISTRIES[@]} registry"
 fi
+
+echo "strict-ssl=${STRICT_SSL}" >>"$NPMRC"
 
 echo "📝 Конфигурация NPM сохранена в ${NPMRC}"
 

--- a/.github/actions/resolve-context/action.yml
+++ b/.github/actions/resolve-context/action.yml
@@ -28,6 +28,12 @@ inputs:
     default: ${{ github.repository }}
     description: Имя образа
 
+  technical-tag-prefix:
+    required: false
+    type: string
+    default: sha-
+    description: Префикс технического тега, добавляемого в режиме feature
+
 outputs:
   ref:
     value: ${{ steps.resolve.outputs.ref }}
@@ -60,6 +66,7 @@ runs:
         INPUT_TAG: ${{ inputs.tag }}
         INPUT_REGISTRY: ${{ inputs.registry }}
         INPUT_IMAGE_NAME: ${{ inputs.image-name }}
+        INPUT_TECHNICAL_TAG_PREFIX: ${{ inputs.technical-tag-prefix }}
         COMMIT_SHA: ${{ github.sha }}
       run: |
         set -euo pipefail
@@ -78,7 +85,7 @@ runs:
 
         if [[ "$INPUT_MODE" == "feature" ]]; then
           REF="${GITHUB_REF}"
-          TAG="sha-${COMMIT_SHA}"
+          TAG="${INPUT_TECHNICAL_TAG_PREFIX}${COMMIT_SHA}"
           VERSION=""
           IMAGE_REFERENCES="$REPO:$TAG"
 

--- a/.github/actions/validate-ref-on-master/action.yml
+++ b/.github/actions/validate-ref-on-master/action.yml
@@ -1,26 +1,39 @@
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 
-name: Validate ref on master
-description: Проверка, что переданный git-ref находится в master-ветке
+name: Validate ref on base branch
+description: Проверка, что переданный git-ref находится в базовой ветке
 
 inputs:
   ref:
     required: true
     description: git-ref (commit hash, branch, tag)
 
+  base-branch:
+    required: false
+    default: master
+    description: Ветка, в которой должен находиться проверяемый ref
+
 runs:
   using: composite
   steps:
-    - name: 🔍 Validate ref on master
+    - name: 🔍 Validate ref on base branch
       shell: bash
-      # Значение приходит переменной окружения, а не подстановкой в текст
+      # Значения приходят переменными окружения, а не подстановкой в текст
       # скрипта: подставленное значение стало бы частью кода.
       env:
         INPUT_REF: ${{ inputs.ref }}
+        INPUT_BASE_BRANCH: ${{ inputs.base-branch }}
       run: |
         set -euo pipefail
 
         REF="$INPUT_REF"
+        BASE_BRANCH="$INPUT_BASE_BRANCH"
+
+        if [[ -z "$BASE_BRANCH" ]]; then
+          echo "❌ base-branch не задан"
+          exit 1
+        fi
+
         echo "🔎 Checking ref: $REF"
 
         if ! REF_COMMIT="$(git rev-parse "$REF" 2>/dev/null)"; then
@@ -30,11 +43,11 @@ runs:
 
         echo "📝 Ref commit: $REF_COMMIT"
 
-        git fetch --no-tags origin master
+        git fetch --no-tags origin "$BASE_BRANCH"
 
-        if git merge-base --is-ancestor "$REF_COMMIT" origin/master; then
-          echo "✅ Ref $REF is on master"
+        if git merge-base --is-ancestor "$REF_COMMIT" "origin/$BASE_BRANCH"; then
+          echo "✅ Ref $REF is on $BASE_BRANCH"
         else
-          echo "❌ Ref $REF is NOT on master"
+          echo "❌ Ref $REF is NOT on $BASE_BRANCH"
           exit 1
         fi

--- a/.github/workflows/docker-cleanup.yml
+++ b/.github/workflows/docker-cleanup.yml
@@ -3,7 +3,8 @@
 name: (reusable) Docker cleanup images with technical tags
 description: >
   Переиспользуемый workflow, описывающий удаление docker-образов.
-  Будут удалены образы, теги которых начинаются с 'sha-', и которые старше указанного возраста
+  Будут удалены образы, теги которых начинаются с заданного префикса (по умолчанию 'sha-'),
+  и которые старше указанного возраста
 
 on:
   workflow_call:
@@ -30,6 +31,20 @@ on:
         default: "false"
         description: Только показать список (не удалять)
 
+      technical-tag-prefix:
+        required: false
+        type: string
+        default: sha-
+        description: Префикс технических тегов, по которому отбираются образы
+
+      image-name:
+        required: false
+        type: string
+        default: ""
+        description: >
+          Имя образа — то же, под которым образ публикуется.
+          По умолчанию имя репозитория
+
 jobs:
   cleanup:
     runs-on: ubuntu-latest
@@ -47,3 +62,5 @@ jobs:
           days-old: ${{ inputs.days-old || '0' }}
           hours-old: ${{ inputs.hours-old || '1' }}
           show-only: ${{ inputs.show-only || 'false' }}
+          technical-tag-prefix: ${{ inputs.technical-tag-prefix || 'sha-' }}
+          image-name: ${{ inputs.image-name || github.repository }}

--- a/.github/workflows/npm-ci.yml
+++ b/.github/workflows/npm-ci.yml
@@ -11,7 +11,43 @@ on:
         required: false
         type: boolean
         default: false
-        description: Сохранять dist/ как артефакт
+        description: Сохранять результат сборки как артефакт
+
+      artifact-name:
+        required: false
+        type: string
+        default: build
+        description: Имя артефакта
+
+      artifact-path:
+        required: false
+        type: string
+        default: dist/
+        description: Что сохранять в артефакт
+
+      artifact-retention-days:
+        required: false
+        type: string
+        default: "1"
+        description: Сколько дней хранить артефакт
+
+      lint-script:
+        required: false
+        type: string
+        default: lint
+        description: npm-скрипт проверки стиля. Пустое значение пропускает шаг
+
+      test-script:
+        required: false
+        type: string
+        default: test
+        description: npm-скрипт тестов. Пустое значение пропускает шаг
+
+      build-script:
+        required: false
+        type: string
+        default: build
+        description: npm-скрипт сборки. Пустое значение пропускает шаг
 
       ref:
         required: false
@@ -75,22 +111,33 @@ jobs:
         shell: bash
         run: npm ci --no-fund
 
+      # Имя скрипта приходит переменной окружения, а не подстановкой в текст
+      # команды: подставленное значение стало бы частью кода.
       - name: 📝 Lint
+        if: ${{ inputs.lint-script != '' }}
         shell: bash
-        run: npm run lint
+        env:
+          NPM_SCRIPT: ${{ inputs.lint-script }}
+        run: npm run "$NPM_SCRIPT"
 
       - name: 🧪 Tests
+        if: ${{ inputs.test-script != '' }}
         shell: bash
-        run: npm test
+        env:
+          NPM_SCRIPT: ${{ inputs.test-script }}
+        run: npm run "$NPM_SCRIPT"
 
       - name: 🛠️ Build
+        if: ${{ inputs.build-script != '' }}
         shell: bash
-        run: npm run build
+        env:
+          NPM_SCRIPT: ${{ inputs.build-script }}
+        run: npm run "$NPM_SCRIPT"
 
       - name: 📦 Upload artifact
         if: ${{ inputs.publish-artifact }}
         uses: actions/upload-artifact@v7
         with:
-          name: build
-          path: dist/
-          retention-days: 1
+          name: ${{ inputs.artifact-name }}
+          path: ${{ inputs.artifact-path }}
+          retention-days: ${{ inputs.artifact-retention-days }}

--- a/.github/workflows/npm-docker-publish.yml
+++ b/.github/workflows/npm-docker-publish.yml
@@ -38,6 +38,36 @@ on:
         default: "20"
         description: Версия Node.js
 
+      base-branch:
+        required: false
+        type: string
+        default: master
+        description: Ветка, в которой должен находиться тег
+
+      technical-tag-prefix:
+        required: false
+        type: string
+        default: sha-
+        description: Префикс технического тега, добавляемого в режиме feature
+
+      lint-script:
+        required: false
+        type: string
+        default: lint
+        description: npm-скрипт проверки стиля. Пустое значение пропускает шаг
+
+      test-script:
+        required: false
+        type: string
+        default: test
+        description: npm-скрипт тестов. Пустое значение пропускает шаг
+
+      build-script:
+        required: false
+        type: string
+        default: build
+        description: npm-скрипт сборки. Пустое значение пропускает шаг
+
       npm-scopes-with-registers:
         type: string
         required: false
@@ -74,6 +104,7 @@ jobs:
           tag: ${{ inputs.tag }}
           registry: ${{ inputs.registry }}
           image-name: ${{ inputs.image-name }}
+          technical-tag-prefix: ${{ inputs.technical-tag-prefix }}
 
       - name: 🛒 Checkout repository
         uses: actions/checkout@v7
@@ -88,11 +119,12 @@ jobs:
         with:
           tag: ${{ steps.ctx.outputs.tag }}
 
-      - name: 🔍 Validate tag on master
+      - name: 🔍 Validate tag on base branch
         if: inputs.mode != 'feature'
         uses: nii-energomash/automation/.github/actions/validate-ref-on-master@master
         with:
           ref: ${{ steps.ctx.outputs.ref }}
+          base-branch: ${{ inputs.base-branch }}
 
       - name: ✨ Setup Node.js (version ${{ inputs.node-version }})
         uses: actions/setup-node@v7
@@ -118,17 +150,28 @@ jobs:
         shell: bash
         run: npm ci --no-fund
 
+      # Имя скрипта приходит переменной окружения, а не подстановкой в текст
+      # команды: подставленное значение стало бы частью кода.
       - name: 📝 Lint
+        if: ${{ inputs.lint-script != '' }}
         shell: bash
-        run: npm run lint
+        env:
+          NPM_SCRIPT: ${{ inputs.lint-script }}
+        run: npm run "$NPM_SCRIPT"
 
       - name: 🧪 Tests
+        if: ${{ inputs.test-script != '' }}
         shell: bash
-        run: npm test
+        env:
+          NPM_SCRIPT: ${{ inputs.test-script }}
+        run: npm run "$NPM_SCRIPT"
 
       - name: 🛠️ Build
+        if: ${{ inputs.build-script != '' }}
         shell: bash
-        run: npm run build
+        env:
+          NPM_SCRIPT: ${{ inputs.build-script }}
+        run: npm run "$NPM_SCRIPT"
 
       - name: 🔐 Log in to container registry (${{ inputs.registry }})
         uses: docker/login-action@v4

--- a/.github/workflows/npm-package-publish.yml
+++ b/.github/workflows/npm-package-publish.yml
@@ -32,6 +32,30 @@ on:
         default: "20"
         description: Версия Node.js
 
+      base-branch:
+        required: false
+        type: string
+        default: master
+        description: Ветка, в которой должен находиться тег
+
+      lint-script:
+        required: false
+        type: string
+        default: lint
+        description: npm-скрипт проверки стиля. Пустое значение пропускает шаг
+
+      test-script:
+        required: false
+        type: string
+        default: test
+        description: npm-скрипт тестов. Пустое значение пропускает шаг
+
+      build-script:
+        required: false
+        type: string
+        default: build
+        description: npm-скрипт сборки. Пустое значение пропускает шаг
+
       npm-scopes-with-registers:
         type: string
         required: false
@@ -70,10 +94,11 @@ jobs:
         with:
           tag: ${{ steps.ctx.outputs.tag }}
 
-      - name: 🔍 Validate tag on master
+      - name: 🔍 Validate tag on base branch
         uses: nii-energomash/automation/.github/actions/validate-ref-on-master@master
         with:
           ref: ${{ steps.ctx.outputs.ref }}
+          base-branch: ${{ inputs.base-branch }}
 
       - name: ✨ Setup Node.js (version ${{ inputs.node-version }})
         uses: actions/setup-node@v7
@@ -99,17 +124,28 @@ jobs:
         shell: bash
         run: npm ci --no-fund
 
+      # Имя скрипта приходит переменной окружения, а не подстановкой в текст
+      # команды: подставленное значение стало бы частью кода.
       - name: 📝 Lint
+        if: ${{ inputs.lint-script != '' }}
         shell: bash
-        run: npm run lint
+        env:
+          NPM_SCRIPT: ${{ inputs.lint-script }}
+        run: npm run "$NPM_SCRIPT"
 
       - name: 🧪 Tests
+        if: ${{ inputs.test-script != '' }}
         shell: bash
-        run: npm test
+        env:
+          NPM_SCRIPT: ${{ inputs.test-script }}
+        run: npm run "$NPM_SCRIPT"
 
       - name: 🛠️ Build
+        if: ${{ inputs.build-script != '' }}
         shell: bash
-        run: npm run build
+        env:
+          NPM_SCRIPT: ${{ inputs.build-script }}
+        run: npm run "$NPM_SCRIPT"
 
       - name: Publish to Github Registry with current Tag
         if: inputs.mode == 'release'


### PR DESCRIPTION
Этап 3.1 отслеживающей задачи #21: захардкоженные значения вынесены во входы.

## Что изменилось

- `validate-ref-on-master` — вход `base-branch` (умолчание `master`), тексты
  сообщений больше не называют master. Каталог действия оставлен прежним:
  путь публичный, по нему может ссылаться кто угодно.
- Шаги `lint`/`test`/`build` — входы `lint-script`, `test-script`,
  `build-script` (умолчания `lint`, `test`, `build`), пустое значение
  пропускает шаг. Правки в трёх github- и трёх gitea-воркфлоу.
- `npm-ci.yml` — входы `artifact-name`, `artifact-path`,
  `artifact-retention-days`.
- `resolve-context` и `docker-cleanup` — вход `technical-tag-prefix`
  (умолчание `sha-`).
- `docker-cleanup` — вход `image-name`: имя пакета теперь берётся оттуда же,
  откуда имя публикуемого образа, а не из `GITHUB_REPOSITORY`.
- Обе копии `npm-registries-configure` — вход `strict-ssl` (умолчание `true`);
  gitea-воркфлоу передают `false`.

Умолчания равны прежнему поведению — контракт для `kdepa-spa` не меняется.

## На что обратить внимание

Одно место, где умолчание не совпадает с прежним поведением: прямой вызов
gitea-действия `npm-registries-configure` из чужого воркфлоу без входа
`strict-ssl` теперь получит `strict-ssl=true` вместо зашитого `false`.
Все три gitea-воркфлоу репозитория передают `false` явно.

`node-version` не трогался: умолчание `"20"` уже одинаково везде, а свести его
в одно место нечем — `env` в `workflow_call.inputs.default` не раскрывается.
Версия по умолчанию фиксируется в README на этапе 5.

## Проверка

- `bash -n` по трём изменённым скриптам
- разбор всех изменённых YAML через `js-yaml`
- `prettier --check` по изменённым файлам
- `cleanup.sh` в режиме `SHOW_ONLY=true` против `nii-energomash/kdepa-spa`:
  при умолчании путь пакета прежний, с явными `image-name`
  и `technical-tag-prefix` подставляются они
- оба `registries-configure.sh` прогнаны локально: `strict-ssl` пишется
  по входу, невалидное значение отбрасывается с ошибкой

Closes #22
