### PR TITLE
chore: примеры отвязаны от адреса реестра и имени пользователя

### DIFF
--- a/.gitea/actions/npm-registries-configure/action.yml
+++ b/.gitea/actions/npm-registries-configure/action.yml
@@ -5,7 +5,7 @@ description: >
   Настраивает регистры NPM для указанных scopes.
   Для работы получает массив строк, разделенный переносом строки,
   и содержащий scope и адрес регистра в формате @<scope>:registry=<uri>.
-  Например: @username:registry=https://192.168.100.252:3000/api/packages/username/npm/
+  Например: @username:registry=https://gitea.example/api/packages/username/npm/
 
 inputs:
   npm-scopes-with-registers:
@@ -14,7 +14,7 @@ inputs:
     default: ""
     description: >
       Массив строк, разделенный переносом строки, и содержащий scope и адрес регистра в формате
-      @<scope>:registry=<uri>. Например: @username:registry=https://192.168.100.252:3000/api/packages/username/npm/
+      @<scope>:registry=<uri>. Например: @username:registry=https://gitea.example/api/packages/username/npm/
 
   node-auth-token:
     type: string

--- a/.gitea/workflows/npm-ci-for-mirror.yml
+++ b/.gitea/workflows/npm-ci-for-mirror.yml
@@ -46,7 +46,7 @@ on:
         default: ""
         description: >
           Массив строк, разделенный переносом строки, и содержащий scope и адрес регистра в формате
-          @\<scope\>:registry=\<uri\>. Например: @username:registry=https://192.168.100.252:3000/api/packages/username/npm/
+          @\<scope\>:registry=\<uri\>. Например: @username:registry=https://gitea.example/api/packages/username/npm/
 
     secrets:
       node-auth-token:

--- a/.gitea/workflows/npm-ci.yml
+++ b/.gitea/workflows/npm-ci.yml
@@ -43,7 +43,7 @@ on:
         default: ""
         description: >
           Массив строк, разделенный переносом строки, и содержащий scope и адрес регистра в формате
-          @\<scope\>:registry=\<uri\>. Например: @username:registry=https://192.168.100.252:3000/api/packages/username/npm/
+          @\<scope\>:registry=\<uri\>. Например: @username:registry=https://gitea.example/api/packages/username/npm/
 
           Обратить внимание:
 

--- a/.gitea/workflows/npm-package-publish.yml
+++ b/.gitea/workflows/npm-package-publish.yml
@@ -62,7 +62,7 @@ on:
         default: ""
         description: >
           Массив строк, разделенный переносом строки, и содержащий scope и адрес регистра в формате
-          @\<scope\>:registry=\<uri\>. Например: @username:registry=https://192.168.100.252:3000/api/packages/username/npm/
+          @\<scope\>:registry=\<uri\>. Например: @username:registry=https://gitea.example/api/packages/username/npm/
 
     secrets:
       node-auth-token:

--- a/examples/gitea/npm-packages/ci.yml
+++ b/examples/gitea/npm-packages/ci.yml
@@ -14,4 +14,4 @@ jobs:
     with:
       node-version: "20"
     secrets:
-      node-auth-token: ${{ secrets.PACKAGES_READ_TOKEN }}
+      node-auth-token: ${{ secrets.GT_PACKAGES_TOKEN }}

--- a/examples/gitea/npm-packages/pr.yml
+++ b/examples/gitea/npm-packages/pr.yml
@@ -13,4 +13,4 @@ jobs:
     with:
       node-version: "20"
     secrets:
-      node-auth-token: ${{ secrets.PACKAGES_READ_TOKEN }}
+      node-auth-token: ${{ secrets.GT_PACKAGES_TOKEN }}

--- a/examples/gitea/npm-packages/publish-with-tag.yml
+++ b/examples/gitea/npm-packages/publish-with-tag.yml
@@ -16,6 +16,6 @@ jobs:
       mode: release
       node-version: "20"
       npm-scopes-with-registers: |
-        @andrey-aka-skif:registry=https://192.168.100.252:3000/api/packages/usov-andrey/npm/
+        @${{ vars.NPM_SCOPE }}:registry=${{ vars.NPM_REGISTRY_URL }}
     secrets:
-      node-auth-token: ${{ secrets.PACKAGES_PUBLISH_TOKEN }}
+      node-auth-token: ${{ secrets.GT_PACKAGES_TOKEN }}

--- a/examples/gitea/npm-packages/republish-with-tag-manually.yml
+++ b/examples/gitea/npm-packages/republish-with-tag-manually.yml
@@ -27,6 +27,6 @@ jobs:
       npm-tag: ${{ inputs.npm-tag }}
       node-version: "20"
       npm-scopes-with-registers: |
-        @andrey-aka-skif:registry=https://192.168.100.252:3000/api/packages/usov-andrey/npm/
+        @${{ vars.NPM_SCOPE }}:registry=${{ vars.NPM_REGISTRY_URL }}
     secrets:
-      node-auth-token: ${{ secrets.PACKAGES_PUBLISH_TOKEN }}
+      node-auth-token: ${{ secrets.GT_PACKAGES_TOKEN }}

--- a/examples/github/npm-images/ci.yml
+++ b/examples/github/npm-images/ci.yml
@@ -16,7 +16,7 @@ jobs:
     with:
       node-version: "20"
       npm-scopes-with-registers: |
-        @andrey-aka-skif:registry=https://npm.pkg.github.com
-        @nii-energomash:registry=https://npm.pkg.github.com
+        @${{ vars.NPM_SCOPE }}:registry=${{ vars.NPM_REGISTRY_URL }}
+        @${{ vars.NPM_ORG_SCOPE }}:registry=${{ vars.NPM_REGISTRY_URL }}
     secrets:
-      node-auth-token: ${{ secrets.GITHUB_TOKEN }}
+      node-auth-token: ${{ secrets.GH_PACKAGES_TOKEN }}

--- a/examples/github/npm-images/publish-with-tag.yml
+++ b/examples/github/npm-images/publish-with-tag.yml
@@ -22,8 +22,8 @@ jobs:
       image-name: ${{ github.repository }}
       node-version: '20'
       npm-scopes-with-registers: |
-        @andrey-aka-skif:registry=https://npm.pkg.github.com
-        @nii-energomash:registry=https://npm.pkg.github.com
+        @${{ vars.NPM_SCOPE }}:registry=${{ vars.NPM_REGISTRY_URL }}
+        @${{ vars.NPM_ORG_SCOPE }}:registry=${{ vars.NPM_REGISTRY_URL }}
     secrets:
-      node-auth-token: ${{ secrets.PACKAGE_PUBLISH_TOKEN }}
+      node-auth-token: ${{ secrets.GH_PACKAGES_TOKEN }}
       docker-auth-token: ${{ secrets.GITHUB_TOKEN }}

--- a/examples/github/npm-images/publish-with-technical-tag.yml
+++ b/examples/github/npm-images/publish-with-technical-tag.yml
@@ -21,8 +21,8 @@ jobs:
       image-name: ${{ github.repository }}
       node-version: '20'
       npm-scopes-with-registers: |
-        @andrey-aka-skif:registry=https://npm.pkg.github.com
-        @nii-energomash:registry=https://npm.pkg.github.com
+        @${{ vars.NPM_SCOPE }}:registry=${{ vars.NPM_REGISTRY_URL }}
+        @${{ vars.NPM_ORG_SCOPE }}:registry=${{ vars.NPM_REGISTRY_URL }}
     secrets:
-      node-auth-token: ${{ secrets.PACKAGE_PUBLISH_TOKEN }}
+      node-auth-token: ${{ secrets.GH_PACKAGES_TOKEN }}
       docker-auth-token: ${{ secrets.GITHUB_TOKEN }}

--- a/examples/github/npm-images/republish-with-tag-manually.yml
+++ b/examples/github/npm-images/republish-with-tag-manually.yml
@@ -28,8 +28,8 @@ jobs:
       image-name: ${{ github.repository }}
       node-version: '20'
       npm-scopes-with-registers: |
-        @andrey-aka-skif:registry=https://npm.pkg.github.com
-        @nii-energomash:registry=https://npm.pkg.github.com
+        @${{ vars.NPM_SCOPE }}:registry=${{ vars.NPM_REGISTRY_URL }}
+        @${{ vars.NPM_ORG_SCOPE }}:registry=${{ vars.NPM_REGISTRY_URL }}
     secrets:
-      node-auth-token: ${{ secrets.PACKAGE_PUBLISH_TOKEN }}
+      node-auth-token: ${{ secrets.GH_PACKAGES_TOKEN }}
       docker-auth-token: ${{ secrets.GITHUB_TOKEN }}

--- a/examples/github/npm-packages/publish-with-tag.yml
+++ b/examples/github/npm-packages/publish-with-tag.yml
@@ -16,6 +16,6 @@ jobs:
       mode: release
       node-version: '20'
       npm-scopes-with-registers: |
-        @andrey-aka-skif:registry=https://npm.pkg.github.com
+        @${{ vars.NPM_SCOPE }}:registry=${{ vars.NPM_REGISTRY_URL }}
     secrets:
-      node-auth-token: ${{ secrets.PACKAGES_PUBLISH_TOKEN }}
+      node-auth-token: ${{ secrets.GH_PACKAGES_TOKEN }}

--- a/examples/github/npm-packages/republish-with-tag-manually.yml
+++ b/examples/github/npm-packages/republish-with-tag-manually.yml
@@ -27,6 +27,6 @@ jobs:
       npm-tag: ${{ inputs.npm-tag }}
       node-version: "20"
       npm-scopes-with-registers: |
-        @andrey-aka-skif:registry=https://npm.pkg.github.com
+        @${{ vars.NPM_SCOPE }}:registry=${{ vars.NPM_REGISTRY_URL }}
     secrets:
-      node-auth-token: ${{ secrets.PACKAGES_PUBLISH_TOKEN }}
+      node-auth-token: ${{ secrets.GH_PACKAGES_TOKEN }}


### PR DESCRIPTION
Этап 3.2 отслеживающей задачи #21.

## Что сделано

- В примерах scope и адрес реестра переданы через `vars`: `NPM_SCOPE`,
  `NPM_ORG_SCOPE` (два scope в `npm-images`) и `NPM_REGISTRY_URL`.
  Работает потому, что примеры живут у потребителя: «For reusable workflows,
  the variables from the caller workflow's repository are used».
- Имена секретов приведены к соглашению организации: `GH_PACKAGES_TOKEN`
  в github-примерах, `GT_PACKAGES_TOKEN` в gitea-примерах (Gitea
  автоматического токена не выдаёт, PAT нужен всегда).
- `examples/github/npm-images/ci.yml`: `node-auth-token` переведён
  с `GITHUB_TOKEN` на `GH_PACKAGES_TOKEN` — встроенный токен не отдаёт пакет
  из чужого репозитория, и пример с приватным scope не работал.
- IP реестра убран из `description:` gitea-воркфлоу и действия
  `npm-registries-configure` (5 мест).

## Что сознательно не сделано

- Строки `uses:` не тронуты: выражения в этом ключе не раскрываются
  («You cannot use contexts or expressions in this keyword»), а стабильного
  DNS-имени у Gitea нет. 11 строк остаются с литеральным
  `192.168.100.252:3000`; требование записано в #2, появление имени
  потребует `v1.1.0`.
- `examples/github/npm-packages/{ci,pr}.yml`: `node-auth-token` остался
  `GITHUB_TOKEN` — приватный scope там не настраивается вообще.
- `docker-auth-token` везде остался `GITHUB_TOKEN`: образ публикуется
  в пакет своего же репозитория.

## Проверка

Прогонять негде — раннер Gitea и потребитель на GitHub вне досягаемости,
проверка статическая: `192.168.100.252` и `usov-andrey` остались только
в `uses:`, `andrey-aka-skif` в репозитории больше нет, старых имён секретов
(`PACKAGES_PUBLISH_TOKEN`, `PACKAGE_PUBLISH_TOKEN`, `PACKAGES_READ_TOKEN`)
не осталось.

Closes #24
